### PR TITLE
If a file exceeds the 2 GB limit of the Protocol Buffer, the weight of the file is output to an external file.

### DIFF
--- a/json2onnx/__init__.py
+++ b/json2onnx/__init__.py
@@ -1,3 +1,3 @@
 from json2onnx.json2onnx import convert, main
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'

--- a/json2onnx/json2onnx.py
+++ b/json2onnx/json2onnx.py
@@ -79,7 +79,12 @@ def convert(
     onnx_graph = Parse(onnx_str, onnx.ModelProto())
 
     if output_onnx_file_path:
-        onnx.save(onnx_graph, output_onnx_file_path)
+        try:
+            onnx.save(onnx_graph, output_onnx_file_path)
+        except ValueError as ve:
+            # If a file exceeds the 2 GB limit of the Protocol Buffer, the weight of the file is output to an external file.
+            # ValueError: Message onnx.ModelProto exceeds maximum protobuf size of 2GB: 3438550359
+            onnx.save(onnx_graph, output_onnx_file_path, save_as_external_data=True)
 
     return onnx_graph
 


### PR DESCRIPTION
- If a file exceeds the 2 GB limit of the Protocol Buffer, the weight of the file is output to an external file.
  ![image](https://github.com/PINTO0309/json2onnx/assets/33194443/9d7e745a-e446-4a79-96bf-c4158b04e941)
